### PR TITLE
feat: add PHP 7.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^7.4",
         "ext-json": "*",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.0",
         "psr/http-client": "^1.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.9",
-        "phpunit/phpunit": "^10.5",
-        "phpstan/phpstan": "^2.1",
-        "laravel/pint": "^1.20"
+        "guzzlehttp/guzzle": "^7.0",
+        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^1.0"
     },
     "prefer-stable": true
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -30,24 +30,20 @@ class Api
     /**
      * Initialize the API request with an HTTP client.
      *
-     * @param  ZatcaEnvironmentEnum|string  $environment  The environment to make requests (production|emulation|sandbox).
-     * @param  ClientInterface  $httpClient  The HTTP client for sending requests.
-     * @param  ?string  $certificate  The certificate for auth.
-     * @param  ?string  $secret  The secret of the certificate for auth.
+     * @param ZatcaEnvironmentEnum|string $environment The environment to make requests (production|simulation|sandbox).
+     * @param ClientInterface             $httpClient   The HTTP client for sending requests.
+     * @param string|null                 $certificate  The certificate for auth.
+     * @param string|null                 $secret       The secret of the certificate for auth.
      */
-    public function __construct(
-        ZatcaEnvironmentEnum|string $environment,
-        ClientInterface $httpClient,
-        ?string $certificate = null,
-        ?string $secret = null,
-    ) {
+    public function __construct($environment, ClientInterface $httpClient, ?string $certificate = null, ?string $secret = null)
+    {
         if (is_string($environment)) {
             $environment = ZatcaEnvironmentEnum::from($environment);
         }
 
         $this->environment = $environment;
-        $this->baseUrl = $environment->url();
-        $this->httpClient = $httpClient;
+        $this->baseUrl     = $environment->url();
+        $this->httpClient  = $httpClient;
 
         $this->setCredentials($certificate, $secret);
     }
@@ -58,17 +54,17 @@ class Api
     public function reporting(string $signedInvoice, ?string $invoiceHash, string $uuid, bool $clearanceStatus = true): ReportingResponse
     {
         $rawResponse = $this->request(
-            endpoint: ZatcaEndpointEnum::Reporting->value,
-            payload: [
+            ZatcaEndpointEnum::REPORTING,
+            [
                 'invoice' => base64_encode($signedInvoice),
                 'invoiceHash' => $this->normalizeInvoiceHash($invoiceHash),
                 'uuid' => $uuid,
             ],
-            headers: [
+            [
                 'Clearance-Status' => $clearanceStatus ? 1 : 0,
             ],
-            authToken: true,
-            method: 'POST',
+            true,
+            'POST'
         );
         $response = new ReportingResponse($rawResponse);
 
@@ -88,17 +84,17 @@ class Api
     public function clearance(string $signedInvoice, ?string $invoiceHash, string $uuid, bool $clearanceStatus = true): ClearanceResponse
     {
         $rawResponse = $this->request(
-            endpoint: ZatcaEndpointEnum::Clearance->value,
-            payload: [
+            ZatcaEndpointEnum::CLEARANCE,
+            [
                 'invoice' => base64_encode($signedInvoice),
                 'invoiceHash' => $this->normalizeInvoiceHash($invoiceHash),
                 'uuid' => $uuid,
             ],
-            headers: [
+            [
                 'Clearance-Status' => $clearanceStatus ? 1 : 0,
             ],
-            authToken: true,
-            method: 'POST',
+            true,
+            'POST'
         );
         $response = new ClearanceResponse($rawResponse);
 
@@ -120,14 +116,15 @@ class Api
     public function compliance(string $signedInvoice, ?string $invoiceHash, string $uuid): ComplianceResponse
     {
         $rawResponse = $this->request(
-            endpoint: ZatcaEndpointEnum::Compliance->value,
-            payload: [
+            ZatcaEndpointEnum::COMPLIANCE,
+            [
                 'invoice' => base64_encode($signedInvoice),
                 'invoiceHash' => $this->normalizeInvoiceHash($invoiceHash),
                 'uuid' => $uuid,
             ],
-            authToken: true,
-            method: 'POST',
+            [],
+            true,
+            'POST'
         );
 
         $response = new ComplianceResponse($rawResponse);
@@ -149,10 +146,11 @@ class Api
     public function complianceCertificate(string $csr, string $otp): CertificateResponse
     {
         $rawResponse = $this->request(
-            endpoint: ZatcaEndpointEnum::ComplianceCertificate->value,
-            payload: ['csr' => base64_encode($csr)],
-            headers: ['OTP' => $otp],
-            authToken: false,
+            ZatcaEndpointEnum::COMPLIANCE_CERTIFICATE,
+            ['csr' => base64_encode($csr)],
+            ['OTP' => $otp],
+            false,
+            'POST'
         );
         $response = new ComplianceCertificateResponse($rawResponse);
 
@@ -173,9 +171,11 @@ class Api
     public function productionCertificate(string $complianceRequestId): ProductionCertificateResponse
     {
         $rawResponse = $this->request(
-            endpoint: ZatcaEndpointEnum::ProductionCertificate->value,
-            payload: ['compliance_request_id' => $complianceRequestId],
-            authToken: true,
+            ZatcaEndpointEnum::PRODUCTION_CERTIFICATE,
+            ['compliance_request_id' => $complianceRequestId],
+            [],
+            true,
+            'POST'
         );
 
         $response = new ProductionCertificateResponse($rawResponse);
@@ -197,10 +197,11 @@ class Api
     public function renewProductionCertificate(string $csr, string $otp): RenewalProductionCertificateResponse
     {
         $rawResponse = $this->request(
-            endpoint: ZatcaEndpointEnum::ProductionCertificate->value,
-            payload: ['csr' => base64_encode($csr)],
-            headers: ['OTP' => $otp],
-            authToken: false,
+            ZatcaEndpointEnum::PRODUCTION_CERTIFICATE,
+            ['csr' => base64_encode($csr)],
+            ['OTP' => $otp],
+            false,
+            'POST'
         );
 
         $response = new RenewalProductionCertificateResponse($rawResponse);

--- a/src/AuthToken.php
+++ b/src/AuthToken.php
@@ -8,14 +8,27 @@ class AuthToken
     private string $token;
 
     /**
+     * @var string
+     */
+    protected $certificate;
+
+    /**
+     * @var string
+     */
+    protected $secret;
+
+    /**
      * Constructor accepts a certificate and a secret,
      * then generates a token in the format base64(base64(certificate):secret)
      *
      * @param  string  $certificate  - The certificate string
-     * @param  string  $secret  - The secret key
+     * @param  string  $secret       - The secret key
      */
-    public function __construct(protected string $certificate, protected string $secret)
+    public function __construct(string $certificate, string $secret)
     {
+        $this->certificate = $certificate;
+        $this->secret      = $secret;
+
         // Trim inputs, double base64 encode the certificate,
         // concatenate with secret separated by ':', then base64 encode the whole string
         $this->token = base64_encode(base64_encode(trim($certificate)).':'.trim($secret));

--- a/src/Enums/ZatcaEndpointEnum.php
+++ b/src/Enums/ZatcaEndpointEnum.php
@@ -2,15 +2,25 @@
 
 namespace Sevaske\ZatcaApi\Enums;
 
-enum ZatcaEndpointEnum: string
+class ZatcaEndpointEnum
 {
-    case Reporting = 'invoices/reporting/single';
+    public const REPORTING = 'invoices/reporting/single';
+    public const CLEARANCE = 'invoices/clearance/single';
+    public const COMPLIANCE = 'compliance/invoices';
+    public const COMPLIANCE_CERTIFICATE = 'compliance';
+    public const PRODUCTION_CERTIFICATE = 'production/csids';
 
-    case Clearance = 'invoices/clearance/single';
-
-    case Compliance = 'compliance/invoices';
-
-    case ComplianceCertificate = 'compliance';
-
-    case ProductionCertificate = 'production/csids';
+    /**
+     * @return string[]
+     */
+    public static function values(): array
+    {
+        return [
+            self::REPORTING,
+            self::CLEARANCE,
+            self::COMPLIANCE,
+            self::COMPLIANCE_CERTIFICATE,
+            self::PRODUCTION_CERTIFICATE,
+        ];
+    }
 }

--- a/src/Enums/ZatcaEnvironmentEnum.php
+++ b/src/Enums/ZatcaEnvironmentEnum.php
@@ -2,20 +2,74 @@
 
 namespace Sevaske\ZatcaApi\Enums;
 
-enum ZatcaEnvironmentEnum: string
+use InvalidArgumentException;
+
+class ZatcaEnvironmentEnum
 {
-    case Sandbox = 'sandbox';
+    public const SANDBOX = 'sandbox';
+    public const SIMULATION = 'simulation';
+    public const PRODUCTION = 'production';
 
-    case Simulation = 'simulation';
+    /**
+     * @var string
+     */
+    private $value;
 
-    case Production = 'production';
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function sandbox(): self
+    {
+        return new self(self::SANDBOX);
+    }
+
+    public static function simulation(): self
+    {
+        return new self(self::SIMULATION);
+    }
+
+    public static function production(): self
+    {
+        return new self(self::PRODUCTION);
+    }
+
+    /**
+     * @param string $value
+     * @return self
+     */
+    public static function from($value): self
+    {
+        $value = strtolower((string) $value);
+        switch ($value) {
+            case self::SANDBOX:
+                return self::sandbox();
+            case self::SIMULATION:
+                return self::simulation();
+            case self::PRODUCTION:
+                return self::production();
+            default:
+                throw new InvalidArgumentException('Invalid environment: '.$value);
+        }
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
 
     public function url(): string
     {
-        return match ($this->value) {
-            'sandbox' => 'https://gw-fatoora.zatca.gov.sa/e-invoicing/developer-portal/',
-            'simulation' => 'https://gw-fatoora.zatca.gov.sa/e-invoicing/simulation/',
-            'production' => 'https://gw-fatoora.zatca.gov.sa/e-invoicing/core/',
-        };
+        switch ($this->value) {
+            case self::SANDBOX:
+                return 'https://gw-fatoora.zatca.gov.sa/e-invoicing/developer-portal/';
+            case self::SIMULATION:
+                return 'https://gw-fatoora.zatca.gov.sa/e-invoicing/simulation/';
+            case self::PRODUCTION:
+                return 'https://gw-fatoora.zatca.gov.sa/e-invoicing/core/';
+            default:
+                throw new InvalidArgumentException('Invalid environment: '.$this->value);
+        }
     }
 }

--- a/src/Exceptions/ZatcaException.php
+++ b/src/Exceptions/ZatcaException.php
@@ -6,8 +6,15 @@ use Sevaske\ZatcaApi\Interfaces\ZatcaExceptionInterface;
 
 class ZatcaException extends \Exception implements ZatcaExceptionInterface
 {
-    public function __construct(string $message = '', protected array $context = [], int $code = 0, ?\Throwable $previous = null)
+    /**
+     * @var array
+     */
+    protected $context = [];
+
+    public function __construct(string $message = '', array $context = [], int $code = 0, ?\Throwable $previous = null)
     {
+        $this->context = $context;
+
         parent::__construct($message, $code, $previous);
     }
 

--- a/src/Interfaces/ZatcaResponseInterface.php
+++ b/src/Interfaces/ZatcaResponseInterface.php
@@ -13,7 +13,7 @@ interface ZatcaResponseInterface extends ArrayAccess, JsonSerializable
      *
      * @return ResponseInterface|array The raw response.
      */
-    public function raw(): ResponseInterface|array;
+    public function raw();
 
     public function errors(): array;
 }

--- a/src/Responses/CertificateResponse.php
+++ b/src/Responses/CertificateResponse.php
@@ -9,7 +9,10 @@ class CertificateResponse extends ZatcaResponse
         return $this->getOptionalAttribute('dispositionMessage') === 'ISSUED';
     }
 
-    public function requestId(): mixed
+    /**
+     * @return mixed
+     */
+    public function requestId()
     {
         return $this->getOptionalAttribute('requestID');
     }

--- a/src/Responses/ZatcaResponse.php
+++ b/src/Responses/ZatcaResponse.php
@@ -13,14 +13,21 @@ class ZatcaResponse implements ZatcaResponseInterface
     use HasAttributes;
 
     /**
+     * @var ResponseInterface|array
+     */
+    protected $response;
+
+    /**
      * Constructs the ApiResponse object by parsing a PSR-7 response into attributes.
      *
-     * @param  ResponseInterface|array  $response  The original PSR-7 HTTP response OR array.
+     * @param  ResponseInterface|array $response The original PSR-7 HTTP response OR array.
      *
      * @throws ZatcaException If the response body cannot be parsed as valid JSON.
      */
-    public function __construct(protected ResponseInterface|array $response)
+    public function __construct($response)
     {
+        $this->response = $response;
+
         if ($response instanceof ResponseInterface) {
             $this->attributes = self::parse($response);
         } else {
@@ -28,7 +35,10 @@ class ZatcaResponse implements ZatcaResponseInterface
         }
     }
 
-    public function raw(): ResponseInterface|array
+    /**
+     * @return ResponseInterface|array
+     */
+    public function raw()
     {
         return $this->response;
     }

--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -25,10 +25,10 @@ trait HasAttributes
     /**
      * Magic method to set the value of a dynamic attribute.
      *
-     * @param  string  $name  The name of the attribute.
-     * @param  mixed  $value  The value to assign to the attribute.
+     * @param  string $name  The name of the attribute.
+     * @param  mixed  $value The value to assign to the attribute.
      */
-    public function __set(string $name, mixed $value)
+    public function __set(string $name, $value)
     {
         $this->attributes[$name] = $value;
     }
@@ -57,12 +57,12 @@ trait HasAttributes
     /**
      * Retrieves an attribute value.
      *
-     * @param  string  $key  The attribute key.
-     * @return mixed The attribute value.
+     * @param  string $key The attribute key.
+     * @return mixed       The attribute value.
      *
      * @throws InvalidArgumentException
      */
-    protected function getAttribute(string $key): mixed
+    protected function getAttribute(string $key)
     {
         if (! isset($this->attributes[$key])) {
             throw new InvalidArgumentException('Undefined attribute: '.$key);
@@ -74,10 +74,10 @@ trait HasAttributes
     /**
      * Retrieves an attribute value or null if undefined.
      *
-     * @param  string  $key  The attribute key.
+     * @param  string $key The attribute key.
      * @return mixed|null The attribute value or null if not found.
      */
-    protected function getOptionalAttribute(string $key): mixed
+    protected function getOptionalAttribute(string $key)
     {
         return $this->attributes[$key] ?? null;
     }
@@ -85,10 +85,10 @@ trait HasAttributes
     /**
      * Checks whether the given offset exists in the internal attributes.
      *
-     * @param  mixed  $offset  The attribute key.
+     * @param  mixed $offset The attribute key.
      * @return bool True if set, false otherwise.
      */
-    public function offsetExists(mixed $offset): bool
+    public function offsetExists($offset): bool
     {
         return isset($this->attributes[$offset]);
     }
@@ -96,10 +96,10 @@ trait HasAttributes
     /**
      * Retrieves a value by array key (offset).
      *
-     * @param  mixed  $offset  The attribute key.
+     * @param  mixed $offset The attribute key.
      * @return mixed|null The attribute value, or null if not set.
      */
-    public function offsetGet(mixed $offset): mixed
+    public function offsetGet($offset)
     {
         return $this->attributes[$offset] ?? null;
     }
@@ -107,10 +107,10 @@ trait HasAttributes
     /**
      * Sets a value by array key (offset).
      *
-     * @param  mixed  $offset  The attribute key.
-     * @param  mixed  $value  The value to set.
+     * @param  mixed $offset The attribute key.
+     * @param  mixed $value  The value to set.
      */
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetSet($offset, $value): void
     {
         $this->attributes[$offset] = $value;
     }
@@ -118,9 +118,9 @@ trait HasAttributes
     /**
      * Unsets a value by array key (offset).
      *
-     * @param  mixed  $offset  The attribute key.
+     * @param  mixed $offset The attribute key.
      */
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset($offset): void
     {
         unset($this->attributes[$offset]);
     }

--- a/src/Traits/RequestBuilder.php
+++ b/src/Traits/RequestBuilder.php
@@ -60,11 +60,11 @@ trait RequestBuilder
     /**
      * Core request handling with Guzzle.
      *
-     * @param  string  $endpoint  API endpoint.
-     * @param  array  $headers  Additional headers.
-     * @param  array  $payload  Request payload.
-     * @param  bool|AuthToken  $authToken  To add the auth token.
-     * @param  string  $method  HTTP method.
+     * @param  string        $endpoint   API endpoint.
+     * @param  array         $payload    Request payload.
+     * @param  array         $headers    Additional headers.
+     * @param  bool|AuthToken $authToken To add the auth token.
+     * @param  string        $method     HTTP method.
      * @return ResponseInterface Response.
      *
      * @throws ZatcaRequestException|ZatcaResponseException
@@ -73,8 +73,8 @@ trait RequestBuilder
         string $endpoint = '',
         array $payload = [],
         array $headers = [],
-        bool|AuthToken $authToken = false,
-        string $method = 'POST',
+        $authToken = false,
+        string $method = 'POST'
     ): ResponseInterface {
         $headers = array_merge([
             'Accept' => 'application/json',


### PR DESCRIPTION
## Summary
- replace enums with class constants and helper methods
- drop PHP 8 syntax: named args, union types, constructor promotion, mixed types
- target PHP 7.4 and compatible dependency versions
- scan remaining files and adjust dev tooling for PHP 7.4

## Testing
- `composer install --no-interaction --ignore-platform-req=php` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890a0e0b00c8331a1721f06b2ffb4e2